### PR TITLE
changed stack_init to init_stack

### DIFF
--- a/src/lua-seri.c
+++ b/src/lua-seri.c
@@ -129,7 +129,7 @@ wb_address(struct write_block *b) {
 }
 
 static inline void
-stack_init(struct stack *s) {
+init_stack(struct stack *s) {
 	s->depth = 0;
 	s->objectid = 0;
 	s->ref_index = 0;
@@ -142,7 +142,7 @@ wb_init(struct write_block *wb , struct block *b) {
 	wb->len = 0;
 	wb->current = wb->head;
 	wb->ptr = 0;
-	stack_init(&wb->s);
+	init_stack(&wb->s);
 }
 
 static void
@@ -165,7 +165,7 @@ rball_init(struct read_block * rb, char * buffer, int size) {
 	rb->buffer = buffer;
 	rb->len = size;
 	rb->ptr = 0;
-	stack_init(&rb->s);
+	init_stack(&rb->s);
 }
 
 static const void *


### PR DESCRIPTION
避免和lua的一个内部函数有相同的名字。这会导致类似onelua的编译方式失败。

https://github.com/lua/lua/blob/be908a7d4d8130264ad67c5789169769f824c5d1/lstate.c#L180