### PR TITLE
remove ATOMIC_VAR_INIT

### DIFF
--- a/src/atomic.h
+++ b/src/atomic.h
@@ -13,8 +13,6 @@ typedef struct {
 	LPVOID volatile v;
 } atomic_ptr;
 
-#define ATOMIC_VAR_INIT(v) { v }
-
 static inline void
 atomic_int_init(atomic_int *aint, int v) {
 	aint->v = (LONG)v;

--- a/src/ltask.c
+++ b/src/ltask.c
@@ -957,7 +957,7 @@ ltask_init_socket(lua_State *L) {
 
 LUAMOD_API int
 luaopen_ltask_bootstrap(lua_State *L) {
-	static atomic_int init = ATOMIC_VAR_INIT(0);
+	static atomic_int init = 0;
 	if (atomic_int_inc(&init) != 1) {
 		return luaL_error(L, "ltask.bootstrap can only require once");
 	}
@@ -1556,7 +1556,7 @@ ltask_closeservice(lua_State *L) {
 
 LUAMOD_API int
 luaopen_ltask_root(lua_State *L) {
-	static atomic_int init = ATOMIC_VAR_INIT(0);
+	static atomic_int init = 0;
 	if (atomic_int_inc(&init) != 1) {
 		return luaL_error(L, "ltask.root can only require once");
 	}


### PR DESCRIPTION
ATOMIC_VAR_INIT is not needed.
see https://en.cppreference.com/w/c/atomic/ATOMIC_VAR_INIT