### PR TITLE
目标消息队列已满的时候，重发消息失败

### DIFF
--- a/service/service.lua
+++ b/service/service.lua
@@ -894,10 +894,10 @@ local function init_exclusive()
 				blocked_message[n+1] = address
 				blocked_message[n+2] = session
 				blocked_message[n+3] = type
-				blocked_message[n+4] = msg
-				blocked_message[n+5] = sz
+				blocked_message[n+4] = msg or false
+				blocked_message[n+5] = sz or false
 			else
-				blocked_message = { address, session, type, msg, sz }
+				blocked_message = { address, session, type, msg or false, sz or false }
 				ltask.fork(retry_blocked_message)
 			end
 		end
@@ -913,8 +913,8 @@ local function init_exclusive()
 			local address = blocked[i]
 			local session = blocked[i+1]
 			local type    = blocked[i+2]
-			local msg     = blocked[i+3]
-			local sz      = blocked[i+4]
+			local msg     = blocked[i+3] or nil
+			local sz      = blocked[i+4] or nil
 			post_message(address, session, type, msg, sz)
 		end
 	end
@@ -1039,6 +1039,7 @@ function ltask.schedule_message()
 			wakeup_session(co, type, session, msg, sz)
 		end
 	else
+		dispatch_wakeup()
 		return SCHEDULE_IDLE
 	end
 	dispatch_wakeup()


### PR DESCRIPTION
重现方式可以修改
```c
#define DEFAULT_QUEUE 4096
```
短一点，大概修改为10，然后增加20个同一时刻的定时器。大概会有16个定时器正常，而剩下4个定时器没有重发，看代码是有重发逻辑。但是有两个问题：
1. 重发逻辑 blocked_message 列表当msg和sz为nil的时候（定时器都是nil），每次添加的长度不再是5，所以在retry_blocked_message 函数中按每5个遍历是不对的；
2. 重发的retry_blocked_message函数，是fork触发的，而timer服务此时由于消息队列为空，始终是idle，而idle没有触发dispatch_wakeup。