### PR TITLE
Allow call ltask.dispatch during init

### DIFF
--- a/service/service.lua
+++ b/service/service.lua
@@ -968,10 +968,8 @@ local function sys_service_init(t)
 		if t.exclusive then
 			init_exclusive()
 		end
-		local r = f(table.unpack(t.args))
-		if service == nil then
-			service = r
-		end
+		local handler = f(table.unpack(t.args))
+		ltask.dispatch(handler)
 	else
 		if t.exclusive then
 			init_exclusive()


### PR DESCRIPTION
在ltask.dispatch的行为改变之后，这里也应该对应地修改。