### PR TITLE
Fix test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 3rd/*
 build/*
+*.so
+*.dll

--- a/test/start.lua
+++ b/test/start.lua
@@ -50,7 +50,7 @@ local function exclusive_thread(label, id)
 end
 
 function print(...)
-	boot.pushlog(ltask.pack(...))
+	boot.pushlog(ltask.pack("info", ...))
 end
 
 local function toclose(f)


### PR DESCRIPTION
解决 gsub 这个报错：
```txt
[Wed Nov 29 10:32:59 2023.38 : sockevent ][INFO ]       (sockevent:3) startup.
[Wed Nov 29 10:32:59 2023.38 : root      ][INFO ]       (root:1) startup.
[Wed Nov 29 10:32:59 2023.38 : timer     ][INFO ]       (timer:2) startup.
[Wed Nov 29 10:32:59 2023.38 : sockevent ][INFO ]       Event fd =      userdata: 0x5
[Wed Nov 29 10:32:59 2023.38 : logger    ][INFO ]       (logger:4) startup.
[Wed Nov 29 10:32:59 2023.38 : logger    ][ERROR]       bad argument #1 to 'gsub' (string expected, got nil)
stack traceback:
        ( service:4 )
        service/logger.lua:81: in upvalue 'writelog'
        service/logger.lua:92: in upvalue 'f'
[Wed Nov 29 10:32:59 2023.38 : bootstrap ][INFO ]       (bootstrap:5) startup.
[Wed Nov 29 10:32:59 2023.38 : bootstrap ][INFO ]       Bootstrap Begin
[Wed Nov 29 10:32:59 2023.38 : bootstrap ][INFO ]       Wed Nov 29 10:32:59 2023
[Wed Nov 29 10:32:59 2023.38 : user      ][INFO ]       (user:6) startup.
[Wed Nov 29 10:32:59 2023.38 : user      ][INFO ]       User init :     Hello
[Wed Nov 29 10:32:59 2023.38 : bootstrap ][INFO ]       Spawn user      6
```