### PR TITLE
allows specifying the chunkname of service.lua

### DIFF
--- a/service/root.lua
+++ b/service/root.lua
@@ -56,7 +56,7 @@ local function new_service(name)
 	if config.worker_bind then
 		worker_id = config.worker_bind[name]
 	end
-	local ok, err = root.init_service(address, name, config.init_service, worker_id)
+	local ok, err = root.init_service(address, name, config.service_source, config.service_chunkname, worker_id)
 	if not ok then
 		return nil, err
 	end

--- a/src/service.c
+++ b/src/service.c
@@ -450,27 +450,12 @@ service_L(struct service_pool *p, service_id id) {
 }
 
 const char *
-service_loadfile(struct service_pool *p, service_id id, const char *filename) {
+service_loadstring(struct service_pool *p, service_id id, const char *source, size_t source_sz, const char *chunkname) {
 	struct service *S= get_service(p, id);
 	if (S == NULL || S->L == NULL)
 		return "Init service first";
 	lua_State *L = S->L;
-	if (luaL_loadfile(L, filename) != LUA_OK) {
-		const char * r = lua_tostring(S->L, -1);
-		S->status = SERVICE_STATUS_DEAD;
-		return r;
-	}
-	S->status = SERVICE_STATUS_IDLE;
-	return NULL;
-}
-
-const char *
-service_loadstring(struct service_pool *p, service_id id, const char *source) {
-	struct service *S= get_service(p, id);
-	if (S == NULL || S->L == NULL)
-		return "Init service first";
-	lua_State *L = S->L;
-	if (luaL_loadstring(L, source) != LUA_OK) {
+	if (luaL_loadbuffer(L, source, source_sz, chunkname) != LUA_OK) {
 		const char * r = lua_tostring(S->L, -1);
 		S->status = SERVICE_STATUS_DEAD;
 		return r;

--- a/src/service.h
+++ b/src/service.h
@@ -38,8 +38,7 @@ const char * service_getlabel(struct service_pool *p, service_id id);
 void service_send_signal(struct service_pool *p, service_id id);
 void service_close(struct service_pool *p, service_id id);
 void service_delete(struct service_pool *p, service_id id);
-const char * service_loadfile(struct service_pool *p, service_id id, const char *filename);
-const char * service_loadstring(struct service_pool *p, service_id id, const char *source);
+const char * service_loadstring(struct service_pool *p, service_id id, const char *source, size_t source_sz, const char *chunkname);
 // 0 yield , 1 term or error
 int service_resume(struct service_pool *p, service_id id, int thread_id);
 int service_thread_id(struct service_pool *p, service_id id);


### PR DESCRIPTION
允许指定service.lua的chunkname,这会对调试器更友好。

同时在可以自定义chunkname后，`service_loadfile(path)`等价于`service_loadstring(readall(path), "@"..path)`,所以还移除了service_loadfile。