### PR TITLE
simplify service init

### DIFF
--- a/service/root.lua
+++ b/service/root.lua
@@ -80,10 +80,7 @@ end
 function S.spawn(name, ...)
 	local address = assert(new_service(name))
 	ltask.syscall(address, "init", {
-		preload = config.preload,
-		lua_path = config.lua_path,
-		lua_cpath = config.lua_cpath,
-		service_path = config.service_path,
+		initfunc = config.initfunc,
 		name = name,
 		args = {...},
 	})
@@ -208,10 +205,7 @@ local function bootstrap()
 			namemap[sid] = label
 			unique[label] = true
 			request:add { sid, proto = "system", "init", {
-				preload = config.preload,
-				lua_path = config.lua_path,
-				lua_cpath = config.lua_cpath,
-				service_path = config.service_path,
+				initfunc = config.initfunc,
 				name = label,
 				args = t.args or {},
 			}}
@@ -221,10 +215,7 @@ local function bootstrap()
 		if sid then
 			namemap[sid] = label
 			unique[label] = true
-			request:add { sid, proto = "system", "init", {
-				lua_path = config.lua_path,
-				lua_cpath = config.lua_cpath,
-			}}
+			request:add { sid, proto = "system", "init", {}}
 			goto continue
 		end
 		sid = assert(new_service(label))
@@ -233,10 +224,7 @@ local function bootstrap()
 			unique[label] = true
 		end
 		request:add { sid, proto = "system", "init", {
-			preload = config.preload,
-			lua_path = config.lua_path,
-			lua_cpath = config.lua_cpath,
-			service_path = config.service_path,
+			initfunc = config.initfunc,
 			name = label,
 			args = t.args or {},
 		}}

--- a/service/service.lua
+++ b/service/service.lua
@@ -1032,25 +1032,11 @@ end
 local function sys_service_init(t)
 	-- The first system message
 	_G.require = yieldable_require
-	if t.preload then
-		if t.preload:sub(1,1) == "@" then
-			assert(loadfile(t.preload:sub(2)))()
-		else
-			assert(load(t.preload))()
-		end
-	end
-	if t.lua_path then
-		package.path = t.lua_path
-	end
-	if t.lua_cpath then
-		package.cpath = t.lua_cpath
-	end
 	if t.name then
-		local filename = assert(package.searchpath(t.name, t.service_path))
-		local f = assert(loadfile(filename))
-		local handler = f(table.unpack(t.args))
+		local initfunc = assert(load(t.initfunc))
+		local func = assert(initfunc(t.name))
+		local handler = func(table.unpack(t.args))
 		ltask.dispatch(handler)
-	else
 	end
 	if service == nil then
 		ltask.quit()


### PR DESCRIPTION
将preload，lua_path，lua_cpath，service_path合并为initfunc，简化了底层的代码，同时提高了灵活性。