### PR TITLE
rework ltask.post_message

### DIFF
--- a/service/timer.lua
+++ b/service/timer.lua
@@ -10,10 +10,6 @@ function timer.quit()
 	ltask.quit()
 end
 
-local send_message = ltask.send_message
-local coroutine_yield = coroutine.yield
-local message_receipt = ltask.message_receipt
-
 local blocked
 
 local mcount = 0
@@ -27,10 +23,8 @@ local function send_all_messages()
 		if blocked_queue then
 			blocked_queue[#blocked_queue+1] = session
 		else
-			send_message(addr, session, MESSAGE_RESPONSE)
 			mcount = mcount + 1
-			coroutine_yield(true)
-			if message_receipt() == RECEIPT_BLOCK then
+			if ltask.post_message(addr, session, MESSAGE_RESPONSE) == RECEIPT_BLOCK then
 				blocked = blocked or {}
 				blocked[addr] = { session }
 			end
@@ -41,9 +35,7 @@ end
 local function send_blocked_queue(addr, queue)
 	local n = #queue
 	for i = 1, n do
-		send_message(addr, queue[i], MESSAGE_RESPONSE)
-		coroutine_yield(true)
-		if message_receipt() == RECEIPT_BLOCK then
+		if ltask.post_message(addr, queue[i], MESSAGE_RESPONSE) == RECEIPT_BLOCK then
 			table.move(queue, i, n, 1)
 			return true
 		end


### PR DESCRIPTION
重新梳理对receipt处理。大幅度简化ltask.post_message，receipt的处理交给调用者，其中包括

1. 系统消息MESSAGE_SCHEDULE_NEW / MESSAGE_SCHEDULE_DEL，每个都比较特殊，所以都单独处理。
2. 请求消息MESSAGE_REQUEST / MESSAGE_SYSTEM，保持原有逻辑，RECEIPT_BLOCK/RECEIPT_ERROR都会直接抛错。
3. 回应消息MESSAGE_RESPONSE / MESSAGE_ERROR，RECEIPT_ERROR消息会被丢弃，RECEIPT_BLOCK会交给root重传。
4. sleep(0)/timeout(0)会给自己发生一个MESSAGE_RESPONSE, RECEIPT_BLOCK/RECEIPT_ERROR都会退化回给timer发消息。
5. root和timer各自实现了一个类似的重传队列，RECEIPT_ERROR消息会被丢弃，RECEIPT_BLOCK会重试。

