### PR TITLE
rework sys_sleep

### DIFF
--- a/src/sysapi.c
+++ b/src/sysapi.c
@@ -26,6 +26,10 @@ sys_sleep(unsigned int msec) {
 
 #include <windows.h>
 
+#ifndef CREATE_WAITABLE_TIMER_HIGH_RESOLUTION
+#    define CREATE_WAITABLE_TIMER_HIGH_RESOLUTION 0x2
+#endif
+
 NTSTATUS NTAPI NtSetTimerResolution(ULONG RequestedResolution, BOOLEAN Set, PULONG ActualResolution);
 
 static int support_hrtimer = 0;

--- a/src/sysapi.c
+++ b/src/sysapi.c
@@ -2,7 +2,9 @@
 
 #ifndef _WIN32
 
-#include <unistd.h>
+#include <assert.h>
+#include <errno.h>
+#include <time.h>
 
 void
 sys_init() {
@@ -10,22 +12,64 @@ sys_init() {
 
 void
 sys_sleep(unsigned int msec) {
-	usleep(msec * 1000);
+	struct timespec timeout;
+	int rc;
+	timeout.tv_sec  = msec / 1000;
+	timeout.tv_nsec = (msec % 1000) * 1000 * 1000;
+	do
+		rc = nanosleep(&timeout, &timeout);
+	while (rc == -1 && errno == EINTR);
+	assert(rc == 0);
 }
 
 #else
 
 #include <windows.h>
 
+NTSTATUS NTAPI NtSetTimerResolution(ULONG RequestedResolution, BOOLEAN Set, PULONG ActualResolution);
+
+static int support_hrtimer = 0;
+
 void
 sys_init() {
-	timeBeginPeriod(1);
+	HANDLE timer = CreateWaitableTimerExW(NULL, NULL, CREATE_WAITABLE_TIMER_HIGH_RESOLUTION, TIMER_ALL_ACCESS);
+	if (timer == NULL) {
+		support_hrtimer = 0;
+	} else {
+		CloseHandle(timer);
+		// supported in Windows 10 1803+
+		support_hrtimer = 1;
+	}
+}
+
+static void hrtimer_start() {
+	if (!support_hrtimer) {
+		ULONG actual_res = 0;
+		NtSetTimerResolution(10000, TRUE, &actual_res);
+	}
+}
+
+static void hrtimer_end() {
+	if (!support_hrtimer) {
+		ULONG actual_res = 0;
+		NtSetTimerResolution(10000, FALSE, &actual_res);
+	}
 }
 
 void
 sys_sleep(unsigned int msec) {
-	Sleep(msec);
+	HANDLE timer = CreateWaitableTimerExW(NULL, NULL, support_hrtimer ? CREATE_WAITABLE_TIMER_HIGH_RESOLUTION : 0, TIMER_ALL_ACCESS);
+	if (!timer) {
+		return;
+	}
+	hrtimer_start();
+	LARGE_INTEGER time;
+	time.QuadPart = -((long long)msec * 10000);
+	if (SetWaitableTimer(timer, &time, 0, NULL, NULL, 0)) {
+		WaitForSingleObject(timer, INFINITE);
+	}
+	CloseHandle(timer);
+	hrtimer_end();
 }
 
 #endif
-


### PR DESCRIPTION
据ms的文档所言，timeBeginPeriod(1)会降低系统的整体性能，也会增加耗电。在windows10 1803之后，windows支持高精度的timer，可以用来实现高精度的sleep。如果不支持，则改成每次sleep之前修改精度，sleep后则恢复。

此外，usleep已经被posix标记为obsolete，所以用nanosleep代替。
