### PR TITLE
编译的时候自动识别OS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 3rd/*
 build/*
 *.so
+*.dSYM
 *.dll

--- a/Makefile
+++ b/Makefile
@@ -3,18 +3,20 @@ CFLAGS=-g -Wall
 
 LUAINC?=`pkgconf lua --cflags`
 
-ifeq ($(OS),Windows_NT)
+UNAME := $(shell uname)
+ifeq ($(UNAME), Linux)
+  SHARED=--shared -fPIC
+  SO=so
+  LIBS=-lpthread
+else ifeq ($(UNAME), Darwin)
+  SO=so
+  SHARED= -fPIC -dynamiclib -Wl,-undefined,dynamic_lookup
+else
+  # Windows
   LIBS=-lwinmm -lws2_32 -D_WIN32_WINNT=0x0601 -lntdll
   SHARED=--shared
   SO=dll
   LUALIB?=`pkgconf lua --libs`
-else ifeq ($(OS), Darwin)
-  SO=so
-  SHARED= -fPIC -dynamiclib -Wl,-undefined,dynamic_lookup
-else
-  SHARED=--shared -fPIC
-  SO=so
-  LIBS=-lpthread
 endif
 
 all : ltask.$(SO)


### PR DESCRIPTION
目前在 mac 上面编译，需要手动传 OS，比较麻烦，改成通过 uname 自动识别。

没有考虑 freebsd 之类，不确定 ltask 能否跑在这些平台上。