### PR TITLE
添加make.lua 的依赖ntdll

### DIFF
--- a/make.lua
+++ b/make.lua
@@ -14,6 +14,7 @@ lm:lua_dll "ltask" {
         links = {
             "ws2_32",
             "winmm",
+            "ntdll",
         }
     },
     msvc = {


### PR DESCRIPTION
现在luamake编译会报错：
sysapi.obj : error LNK2001: 无法解析的外部符号 NtSetTimerResolution
build\bin\ltask.dll : fatal error LNK1120: 1 个无法解析的外部命令
需要添加ntdll的依赖