### PR TITLE
fix(ci/asan): bumped version of runner os

### DIFF
--- a/.github/asan_assets/lsan.supp
+++ b/.github/asan_assets/lsan.supp
@@ -1,0 +1,3 @@
+leak:libobjc.A.dylib
+leak:libxpc.dylib
+leak:libSystem.B.dylib

--- a/.github/asan_assets/test_mem.sh
+++ b/.github/asan_assets/test_mem.sh
@@ -17,6 +17,8 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
     "$LLVM_SDK_PATH"/bin/clang -dynamiclib .github/asan_assets/dlclose.c -o ./.github/asan_assets/libdlclose.dylib -install_name libdlclose.dylib
     # export DYLD_PRINT_LIBRARIES=1 X=1
     export DYLD_INSERT_LIBRARIES="./.github/asan_assets/libdlclose.dylib:$ASAN_LIB_ABS_PATH"
+    # see https://github.com/llvm/llvm-project/issues/115992
+    export ASAN_OPTIONS="detect_leaks=1:suppressions=./github/asan_assets/lsan.supp"
     
     lua test.lua
 else

--- a/.github/workflows/asan.yaml
+++ b/.github/workflows/asan.yaml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         # ref: https://github.com/actions/runner-images
-        os: [ubuntu-20.04, macos-13]
+        os: [ubuntu-latest, macos-latest]
         luaVersion: ["5.4.7", "5.4.6", "5.4.5"]
     runs-on: ${{ matrix.os }}
     steps:

--- a/test.lua
+++ b/test.lua
@@ -2,6 +2,7 @@ local start = require "test.start"
 start {
     core = {
         debuglog = "=", -- stdout
+        worker = 3, -- avoid stuck when running ci on GHA macOS
     },
     service_path = "service/?.lua;test/?.lua",
     bootstrap = {


### PR DESCRIPTION
修复 ci 因为旧版本系统下线而无法运行的问题

另外， GHA 的 macos-latest 只有双核，ltask 会默认创建两个 worker, 而 `test.lua` 中设置了一个 binding service (`user`), 结果会导致测试卡住无法退出，所以我在测试中指定了 workers 数目。

由此可以推测在 n 个 worker 下，如果有 n-1 个 binding service 会导致调度器出现问题卡住。我已在本地验证过确实如此(任意操作系统皆可，以 `test.lua` 为例，限制 worker 数量为2可复现)。我不确定这是否属于一种 bug？ cc @cloudwu 

PS: 现在 GHA macOS runners 挂了, 暂时存在 ci 运行故障。FYI: https://www.githubstatus.com