### PR TITLE
fix(ci/asan): invalid options for supressing incorrect report of leak

### DIFF
--- a/.github/asan_assets/test_mem.sh
+++ b/.github/asan_assets/test_mem.sh
@@ -18,7 +18,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
     # export DYLD_PRINT_LIBRARIES=1 X=1
     export DYLD_INSERT_LIBRARIES="./.github/asan_assets/libdlclose.dylib:$ASAN_LIB_ABS_PATH"
     # see https://github.com/llvm/llvm-project/issues/115992
-    export ASAN_OPTIONS="detect_leaks=1:suppressions=./github/asan_assets/lsan.supp"
+    export LSAN_OPTIONS="suppressions=./.github/asan_assets/lsan.supp"
     
     lua test.lua
 else


### PR DESCRIPTION
升级到 macos-latest 后发现存在误报的问题，详见: https://github.com/llvm/llvm-project/issues/115992

这是 llvm 的 bug, 现在先将其抑制/